### PR TITLE
Fix concurrency issue

### DIFF
--- a/Figgle/StringPool.cs
+++ b/Figgle/StringPool.cs
@@ -24,11 +24,14 @@ namespace Figgle
         /// <returns>A reference to the pooled string.</returns>
         public string Pool(string s)
         {
-            if (_pool.TryGetValue(s, out var pooled))
-                return pooled;
+            lock (_pool)
+            {
+                if (_pool.TryGetValue(s, out var pooled))
+                    return pooled;
 
-            _pool[s] = s;
-            return s;
+                _pool[s] = s;
+                return s;
+            }
         }
     }
 }


### PR DESCRIPTION
I've spotted such an error when using Figgle from multiple threads

```
System.InvalidOperationException
Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Figgle.StringPool.Pool(String s) in /_/Figgle/StringPool.cs:line 27
   at Figgle.FiggleFontParser.<Parse>g__ReadCharacter|4_1(<>c__DisplayClass4_0& ) in /_/Figgle/FiggleFontParser.cs:line 163
   at Figgle.FiggleFontParser.Parse(Stream stream, StringPool pool) in /_/Figgle/FiggleFontParser.cs:line 216
   at Figgle.FiggleFonts.FontFactory(String name) in /_/Figgle/FiggleFonts.cs:line 307
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at Figgle.FiggleFonts.Lookup(String name) in /_/Figgle/FiggleFonts.cs:line 291
   at Figgle.FiggleFonts.get_Standard() in /_/Figgle/FiggleFonts.cs:line 251
```
Test reproducing this error:
```csharp
        [Fact]
        public async Task ParseConcurrently()
        {
            var action = new Action(() =>
            {
                _output.WriteLine(Figgle.FiggleFonts.Standard.Render("Message Xyz"));
            });
            var tasks= Enumerable.Range(1, 10000).Select(_ => Task.Run(action));

            await Task.WhenAll(tasks);
        }
```
NOTE: I had to run this test multiple times, before this error occurred- it is not always present

Changing Dictionary to ConcurrentDictionary fixes this issue.