### PR TITLE
Target netstandard2.0

### DIFF
--- a/Figgle/Figgle.csproj
+++ b/Figgle/Figgle.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>ASCII banner generation for .NET</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/drewnoakes/figgle</PackageProjectUrl>
@@ -24,11 +24,5 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <EmbeddedResource Include="Fonts.zip" />
     <None Include="../images/logo-square-256px.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
-    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    <Reference Include="System.IO.Compression" />
   </ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 0.3.{build}
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration:
 - Release
 - Debug


### PR DESCRIPTION
Fixes #15

Drops support for .NET Core 1.0/1.1 and .NET Framework 4.5.1/4.5.2/4.6, all of which are out of support. Users who require those versions should remain on Figgle version 0.4.1.