### PR TITLE
Generate correct code when class has no namespace

### DIFF
--- a/Figgle.Generator.Tests/EmbedFontSourceGeneratorTests.cs
+++ b/Figgle.Generator.Tests/EmbedFontSourceGeneratorTests.cs
@@ -218,6 +218,40 @@ public class EmbedFontSourceGeneratorTests : SourceGeneratorTests
 
         string generatedCode = compilation.SyntaxTrees.Last().ToString();
         Assert.Contains(
+            "namespace Test.Namespace",
+            generatedCode);
+        Assert.Contains(
+            "public static FiggleFont Foo => _fontByName.GetOrAdd(\"Foo\", _ => FiggleFontParser.ParseString(FooFontDescription, _stringPool));",
+            generatedCode);
+        Assert.Contains(
+            "private static readonly string FooFontDescription = @\"",
+            generatedCode);
+    }
+
+    [Fact]
+    public void ExternalFontInAdditionalFiles_NoNamespace_EmbedsFont()
+    {
+        string source =
+            """
+            using Figgle;
+
+            [EmbedFiggleFont("Foo", "ANSI Shadow")]
+            internal static partial class DemoUsage
+            {
+            }
+            """;
+
+        var additionalFont = ExternalFontAdditionalText.Create("ANSI Shadow.flf");
+        var optionsProvider = CreateOptionsProvider("ANSI Shadow.flf", "ANSI Shadow");
+
+        var (compilation, diagnostics) = RunGenerator(source, [additionalFont], optionsProvider);
+        Assert.Empty(diagnostics);
+
+        string generatedCode = compilation.SyntaxTrees.Last().ToString();
+        Assert.DoesNotContain(
+            "namespace",
+            generatedCode);
+        Assert.Contains(
             "public static FiggleFont Foo => _fontByName.GetOrAdd(\"Foo\", _ => FiggleFontParser.ParseString(FooFontDescription, _stringPool));",
             generatedCode);
         Assert.Contains(

--- a/Figgle.Generator/EmbedFontSourceGenerator.cs
+++ b/Figgle.Generator/EmbedFontSourceGenerator.cs
@@ -283,7 +283,7 @@ internal sealed class EmbedFontSourceGenerator : IIncrementalGenerator
 
             namespace {{ns}}
             {
-                {{GetAccessibility(type.DeclaredAccessibility)}}static partial class {{type.Name}}
+                static partial class {{type.Name}}
                 {
                     private static readonly ConcurrentDictionary<string, FiggleFont> _fontByName = new(StringComparer.Ordinal);
                     private static readonly StringPool _stringPool = new();
@@ -302,7 +302,7 @@ internal sealed class EmbedFontSourceGenerator : IIncrementalGenerator
                 using System.Collections.Concurrent;
                 using Figgle;
 
-                {{GetAccessibility(type.DeclaredAccessibility)}}static partial class {{type.Name}}
+                static partial class {{type.Name}}
                 {
                     private static readonly ConcurrentDictionary<string, FiggleFont> _fontByName = new(StringComparer.Ordinal);
                     private static readonly StringPool _stringPool = new();
@@ -328,20 +328,6 @@ internal sealed class EmbedFontSourceGenerator : IIncrementalGenerator
             }
 
             return builder.ToString();
-        }
-
-        static string GetAccessibility(Accessibility declaredAccessibility)
-        {
-            return declaredAccessibility switch
-            {
-                Accessibility.Public => "public ",
-                Accessibility.Internal => "internal ",
-                Accessibility.Private => "private ",
-                Accessibility.Protected => "protected ",
-                Accessibility.ProtectedAndInternal => "protected internal ",
-                Accessibility.NotApplicable => "",
-                _ => throw new NotImplementedException($"Unexpected accessibility '{declaredAccessibility}'."),
-            };
         }
     }
 


### PR DESCRIPTION
Fixes #30

Generate correct code when class has no namespace.

Removes the accessibility modifier from the generated code, as it's implied by other part(s).

Validated that we also handle the no-namespace case in RenderTextSourceGenerator and test.