### PR TITLE
Produce a reference assembly for build perf

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,6 +35,9 @@
 
     <!-- Suppress NU1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source. -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
+
+    <!-- Improves incremental build performance -->
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Because we target netstandard2.0, MSBuild won't generate reference assemblies by default. Opt into that behaviour to get better incremental build performance.