### PR TITLE
Add multiple partial class definition support for embed font generator

### DIFF
--- a/Figgle.Generator/EmbedFontSourceGenerator.cs
+++ b/Figgle.Generator/EmbedFontSourceGenerator.cs
@@ -103,27 +103,13 @@ internal sealed class EmbedFontSourceGenerator : IIncrementalGenerator
             context.AddSource($"{AttributeName}.cs", AttributeSource);
         });
 
-        var generationInfoProvider = context.SyntaxProvider.ForAttributeWithMetadataName(
+        var generationInfoProvider = context.SyntaxProvider.ForFiggleAttributeWithMetadataName(
             $"{AttributeNamespace}.{AttributeName}",
-            predicate: static (syntaxNode, cancellationToken) => syntaxNode is ClassDeclarationSyntax declaration,
-            transform: (context, cancellationToken) =>
-            {
-                // use hash set to de-dup attributes that are identical.  If an attribute specifies
-                // the same member name multiple times with different font names, we will report a diagnostic
-                // later in RegisterSourceOutput since we can't report diagnostics from here.
-                var attributeInfos = new HashSet<EmbedFontAttributeInfo>(EmbedFontAttributeInfoComparer.Instance);
-                foreach (var matchingAttributeData in context.Attributes)
-                {
-                    attributeInfos.Add(new EmbedFontAttributeInfo(
-                        matchingAttributeData.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation(),
-                        (string?)matchingAttributeData.ConstructorArguments[0].Value,
-                        (string?)matchingAttributeData.ConstructorArguments[1].Value));
-                }
-
-                return new GenerationInfo<EmbedFontAttributeInfo>(
-                    (ITypeSymbol)context.TargetSymbol,
-                    attributeInfos);
-            });
+            createAttributeInfo: (attributeData, cancellationToken) => new EmbedFontAttributeInfo(
+                attributeData.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation(),
+                (string?)attributeData.ConstructorArguments[0].Value,
+                (string?)attributeData.ConstructorArguments[1].Value),
+            EmbedFontAttributeInfoComparer.Instance);
 
         var generationInfos = generationInfoProvider.ConsolidateAttributeInfosByTypeSymbol(
             EmbedFontAttributeInfoComparer.Instance);

--- a/Figgle.Generator/GenerationInfo.cs
+++ b/Figgle.Generator/GenerationInfo.cs
@@ -1,0 +1,10 @@
+﻿// Copyright Drew Noakes. Licensed under the Apache-2.0 license. See the LICENSE file for more details.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Figgle.Generator;
+
+internal readonly record struct GenerationInfo<TAttributeInfo>(
+    ITypeSymbol TargetType,
+    HashSet<TAttributeInfo> AttributeInfos);

--- a/Figgle.Generator/IncrementalGeneratorExtensions.cs
+++ b/Figgle.Generator/IncrementalGeneratorExtensions.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright Drew Noakes. Licensed under the Apache-2.0 license. See the LICENSE file for more details.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Figgle.Generator;
 
-internal static class IncrementalGeneratorContextExtensions
+internal static class IncrementalGeneratorExtensions
 {
     public static IncrementalValueProvider<ImmutableArray<ExternalFont>> GetExternalFontsProvider(
         this IncrementalGeneratorInitializationContext context)
@@ -30,5 +32,25 @@ internal static class IncrementalGeneratorContextExtensions
                     additionalFile.GetText(cancellationToken)?.ToString());
             })
             .Collect();
+    }
+
+    public static IncrementalValueProvider<ImmutableDictionary<ISymbol, ImmutableHashSet<TAttributeInfo>>> ConsolidateAttributeInfosByTypeSymbol<TAttributeInfo>(
+        this IncrementalValuesProvider<GenerationInfo<TAttributeInfo>> attributeInfosProvider,
+        IEqualityComparer<TAttributeInfo>? comparer = null)
+    {
+        return attributeInfosProvider
+            .Collect()
+            .Select((infos, cancellationToken) =>
+            {
+                var typeToGenerateGroup = infos.GroupBy(
+                keySelector: info => info.TargetType,
+                elementSelector: info => info.AttributeInfos,
+                comparer: SymbolEqualityComparer.Default);
+
+                return typeToGenerateGroup.ToImmutableDictionary(
+                    keySelector: group => group.Key!,
+                    elementSelector: group => group.SelectMany(info => info).ToImmutableHashSet(comparer),
+                    keyComparer: SymbolEqualityComparer.Default);
+            });
     }
 }


### PR DESCRIPTION
Currently when multiple partial class definitions of the same class use `[EmbedFiggleFont]`, multiple generated files of the same filenames are produced and the compiler will error due conflicting filenames.

This PR enables support for using `EmbedFiggleFont` on multiple partial class definitions of the same class name and closes #35 .

# Implementation
- Extract the attribute info aggregation code from `RenderTextSourceGenerator` (which does support multiple partial definitions) to an extension method for reuse.
- Update `EmbedFontSourceGenerator` to use the new extension method.
- Also extracted an extension method for creating `GenerationInfo` from attributes on class declarations.
- Updated both generators to use the new extension method to reduce duplicate code.

# Testing
- Added new unit tests for `EmbedFontSourceGenerator` to check multiple partial definitions are working as expected.
- All existing tests continue to pass after extension methods are extracted.