### PR TITLE
Specify 'SmallestSize' compression level for font zip file

### DIFF
--- a/src/Figgle.Fonts/Figgle.Fonts.csproj
+++ b/src/Figgle.Fonts/Figgle.Fonts.csproj
@@ -54,7 +54,13 @@
     <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
 
     <!-- Create the zip file -->
-    <ZipDirectory SourceDirectory="..\..\fonts" DestinationFile="$(FontsZipFile)" Overwrite="true" />
+    <ZipDirectory
+      SourceDirectory="..\..\fonts" DestinationFile="$(FontsZipFile)" Overwrite="true" CompressionLevel="SmallestSize"
+      Condition="'$(MSBuildVersion)' &gt;= '18.0'" />
+    <ZipDirectory
+      SourceDirectory="..\..\fonts" DestinationFile="$(FontsZipFile)" Overwrite="true"
+      Condition="'$(MSBuildVersion)' &lt; '17.0'" />
+
   </Target>
 
 </Project>

--- a/src/Figgle.Fonts/Figgle.Fonts.csproj
+++ b/src/Figgle.Fonts/Figgle.Fonts.csproj
@@ -59,7 +59,7 @@
       Condition="'$(MSBuildVersion)' &gt;= '18.0'" />
     <ZipDirectory
       SourceDirectory="..\..\fonts" DestinationFile="$(FontsZipFile)" Overwrite="true"
-      Condition="'$(MSBuildVersion)' &lt; '17.0'" />
+      Condition="'$(MSBuildVersion)' &lt; '18.0'" />
 
   </Target>
 


### PR DESCRIPTION
Support for this was added in https://github.com/dotnet/msbuild/pull/11975 though it won't be available in versions of MSBuild for a while, nor on older versions in future. I'm opting in on 18.0+, though don't yet know what version it'll ship in.