### PR TITLE
Reduce required compiler version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers" Version="4.14.0" />

--- a/src/Figgle.Fonts.Generator/FiggleFontGenerator.cs
+++ b/src/Figgle.Fonts.Generator/FiggleFontGenerator.cs
@@ -50,7 +50,7 @@ internal sealed class FiggleFontGenerator : IIncrementalGenerator
                 var csvFileContent = file.GetText(cancellationToken)?.ToString();
                 if (csvFileContent is null)
                 {
-                    return [];
+                    return ImmutableArray<FontAlias>.Empty;
                 }
 
                 var aliases = ImmutableArray.CreateBuilder<FontAlias>();


### PR DESCRIPTION
Fixes #49 (hopefully!)

We were requiring version 4.14.0 of Microsoft.CodeAnalysis.CSharp and Microsoft.CodeAnalysis.Analyzers, which brings a dependency on a newer compiler than we actually need.

This change lowers those requirements.